### PR TITLE
[3.2.0] - 2026-06-11

### DIFF
--- a/lib/validates_cnpj/version.rb
+++ b/lib/validates_cnpj/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ValidatesCnpj
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
Release 3.2.0 — bumps `VERSION` to 3.2.0.

Ships alphanumeric CNPJ support (merged in #3): the first 12 positions accept uppercase letters and digits, lowercase input is normalized to uppercase on save, and the existing numeric format stays valid.